### PR TITLE
fixed quote generator for mobile version

### DIFF
--- a/source/SkypeQuoteCreator/MainForm.cs
+++ b/source/SkypeQuoteCreator/MainForm.cs
@@ -221,7 +221,7 @@
             string message = this.uxMessage.Text;
 
             string skypeMessageFragment = String.Format(
-                "<quote author=\"{0}\" timestamp=\"{1}\">{2}</quote>",
+                "<quote authorname=\"{0}\" timestamp=\"{1}\">{2}</quote>",
                 user,
                 (dateTime.ToUniversalTime() - epoch).TotalSeconds,
                 message);


### PR DESCRIPTION
"authorname" should be set in order to work on mobile version, also "author" is not needed at all now.
Tested on desktop version 7.23.85.105 and mobile 6.33.0.575
